### PR TITLE
fix: work with autogenerated schemas that have mandatory nested records

### DIFF
--- a/aether/python/avro/schema.py
+++ b/aether/python/avro/schema.py
@@ -148,6 +148,9 @@ class Node:
         return False
 
     def parse_children(self, source: Mapping[Any, Any]):
+        # node is a mandatory record containing sub-fields
+        if isinstance(source.get('type'), dict):
+            self.parse_children(source.get('type'))
         fields = source.get('fields', [])
         for f in fields:
             self.has_children = True

--- a/aether/python/avro/tests/__init__.py
+++ b/aether/python/avro/tests/__init__.py
@@ -20,12 +20,19 @@ import pytest
 
 from aether.python.tests import (
     EXAMPLE_ALL_TYPES,
-    EXAMPLE_SIMPLE_SCHEMA,
-    EXAMPLE_ANNOTATED_SCHEMA
+    EXAMPLE_ANNOTATED_SCHEMA,
+    EXAMPLE_AUTOGEN_SCHEMA,
+    EXAMPLE_SIMPLE_SCHEMA
 )
 
 from aether.python.avro.schema import Node
 from aether.python.avro.generation import SampleGenerator
+
+
+@pytest.mark.unit
+@pytest.fixture(scope='module')
+def AutoSchema():
+    return Node(EXAMPLE_AUTOGEN_SCHEMA)
 
 
 @pytest.mark.unit

--- a/aether/python/avro/tests/test_schema.py
+++ b/aether/python/avro/tests/test_schema.py
@@ -167,3 +167,14 @@ def test__collect_nodes_by_criteria__fail(ComplexSchema):
     )
     count = sum([1 for (path, node) in matches])
     assert(count == 0)
+
+
+@pytest.mark.unit
+def test__process_autogen_schema_no_union_nested(AutoSchema):
+    # ensure that nested records are processed properly.
+    # I.E. Auto0.geo.latitude should be present
+    matches = AutoSchema.collect_matching(
+        {'match_attr': [{'name': 'latitude'}]}
+    )
+    count = sum([1 for (path, node) in matches])
+    assert(count == 1)

--- a/aether/python/tests/__init__.py
+++ b/aether/python/tests/__init__.py
@@ -878,6 +878,156 @@ EXAMPLE_SIMPLE_SCHEMA = {
 }
 
 
+EXAMPLE_AUTOGEN_SCHEMA = {
+    'type': 'record',
+    'fields': [
+        {
+            'name': 'start',
+            'type': 'string'
+        },
+        {
+            'name': 'end',
+            'type': 'string'
+        },
+        {
+            'name': 'today',
+            'type': 'string'
+        },
+        {
+            'name': 'deviceid',
+            'type': 'string'
+        },
+        {
+            'name': 'phonenumber',
+            'type': 'None'
+        },
+        {
+            'name': 'note_start',
+            'type': 'None'
+        },
+        {
+            'name': 'acknowledge_intro',
+            'type': 'string'
+        },
+        {
+            'name': 'residents_module',
+            'type': {
+                'type': 'record',
+                'fields': [
+                    {
+                        'name': 'supervisor_name',
+                        'type': 'string'
+                    },
+                    {
+                        'name': 'enumerator',
+                        'type': 'string'
+                    },
+                    {
+                        'name': 'cluster',
+                        'type': 'string'
+                    },
+                    {
+                        'name': 'respondent_name',
+                        'type': 'string'
+                    },
+                    {
+                        'name': 'gender',
+                        'type': 'string'
+                    },
+                    {
+                        'name': 'age',
+                        'type': 'int'
+                    },
+                    {
+                        'name': 'connected_discos_supplied',
+                        'type': 'string'
+                    },
+                    {
+                        'name': 'use_alternative_power',
+                        'type': 'string'
+                    },
+                    {
+                        'name': 'largest_source_noise',
+                        'type': 'string'
+                    },
+                    {
+                        'name': 'wish_to_relocate',
+                        'type': 'string'
+                    },
+                    {
+                        'name': 'why_would_you_choose_to_relocat',
+                        'type': 'string'
+                    },
+                    {
+                        'name': 'common_safety_concerns_in_the_market',
+                        'type': 'string'
+                    },
+                    {
+                        'name': 'comments',
+                        'type': 'string'
+                    }
+                ],
+                'name': 'Auto_1'
+            }
+        },
+        {
+            'name': 'pic',
+            'type': 'string'
+        },
+        {
+            'name': 'geo',
+            'type': {
+                'type': 'record',
+                'fields': [
+                    {
+                        'name': 'latitude',
+                        'type': 'float'
+                    },
+                    {
+                        'name': 'longitude',
+                        'type': 'float'
+                    },
+                    {
+                        'name': 'altitude',
+                        'type': 'float'
+                    },
+                    {
+                        'name': 'accuracy',
+                        'type': 'float'
+                    }
+                ],
+                'name': 'Auto_2'
+            }
+        },
+        {
+            'name': 'meta',
+            'type': {
+                'type': 'record',
+                'fields': [
+                    {
+                        'name': 'instanceID',
+                        'type': 'string'
+                    }
+                ],
+                'name': 'Auto_3'
+            }
+        },
+        {
+            'name': 'id',
+            'type': 'string'
+        },
+        {
+            'name': 'es_reserved__id',
+            'type': 'string'
+        },
+        {
+            'name': 'es_reserved__version',
+            'type': 'string'
+        }
+    ],
+    'name': 'Auto_0'
+}
+
 EXAMPLE_ANNOTATED_SCHEMA = {
     'doc': 'MySurvey (title: HS OSM Gather Test id: gth_hs_test, version: 2)',
     'name': 'MySurvey',
@@ -1803,19 +1953,7 @@ EXAMPLE_ANNOTATED_SCHEMA = {
     ],
     'namespace': 'org.ehealthafrica.aether.odk.xforms.Mysurvey'
 }
-'''
-{
-            'doc': 'an optional datetime',
-            'name': 'optional_dt',
-            'type': [
-                'null',
-                {
-                    'type': 'long',
-                    'logicalType': 'datetime-millis'
-                }
-            ]
-        }
-'''
+
 EXAMPLE_ALL_TYPES = {
     'name': 'AllTypes',
     'type': 'record',


### PR DESCRIPTION
Added new tests to cover a different value permutation of avro schemas.